### PR TITLE
Issue #3 and Issue #4

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Site for SkywardAI community.
 
+[![CI](https://github.com/SkywardAI/skywardai.io/actions/workflows/ci.yml/badge.svg)](https://github.com/SkywardAI/skywardai.io/actions/workflows/ci.yml)
+
+[![Deploy Jekyll site to Pages](https://github.com/SkywardAI/skywardai.io/actions/workflows/pages.yml/badge.svg)](https://github.com/SkywardAI/skywardai.io/actions/workflows/pages.yml)
+
 ## Building and previewing your site locally
 
 Assuming [Jekyll] and [Bundler] are installed on your computer:


### PR DESCRIPTION
Fixes [DOC]: Add status icon to the README.md #3

Fixes [DOC]: add deployment to GitHub Page status icon to README.md #4

added status icon and deployment status icon to readme

Signed-off-by: Margaret Xiao s3902846@student.rmit.edu.au